### PR TITLE
refactor: derive ConfigSetting type from ConfigSchema for better maintainability

### DIFF
--- a/src/config/components/SettingForm.tsx
+++ b/src/config/components/SettingForm.tsx
@@ -7,7 +7,7 @@ import validator from "@rjsf/validator-ajv8";
 import { customWidgets } from "../widgets/CustomWidgets";
 
 import type { ConfigSchema } from "../../shared/types/Config";
-import type { Setting } from "../types/ConfigFormTypes";
+import type { ConfigSetting } from "../types/ConfigFormTypes";
 import type { RJSFSchema } from "@rjsf/utils";
 
 const log = (type: string) => console.log.bind(console, type);
@@ -39,7 +39,7 @@ interface SettingFormProps {
   currentTab: number;
   schema: RJSFSchema;
   uiSchema: any;
-  onUpdateSetting: (index: number, settingData: Setting) => void;
+  onUpdateSetting: (index: number, settingData: ConfigSetting) => void;
 }
 
 export const SettingForm: React.FC<SettingFormProps> = ({

--- a/src/config/hooks/useConfigData.ts
+++ b/src/config/hooks/useConfigData.ts
@@ -9,7 +9,7 @@ import {
 } from "../utils/configUtils";
 
 import type { ConfigSchema } from "../../shared/types/Config";
-import type { ConfigFormState, Setting } from "../types/ConfigFormTypes";
+import type { ConfigFormState, ConfigSetting } from "../types/ConfigFormTypes";
 
 export const useConfigData = (initialData: ConfigSchema = { settings: [] }) => {
   const [formData, setFormData] = useState<ConfigSchema>(initialData);
@@ -40,7 +40,7 @@ export const useConfigData = (initialData: ConfigSchema = { settings: [] }) => {
       setCurrentTab(adjustCurrentTab(currentTab, newFormData.settings.length));
     },
 
-    handleUpdateSetting: (index: number, settingData: Setting) => {
+    handleUpdateSetting: (index: number, settingData: ConfigSetting) => {
       const newFormData = updateSetting(formData, index, settingData);
       setFormData(newFormData);
     },

--- a/src/config/types/ConfigFormTypes.ts
+++ b/src/config/types/ConfigFormTypes.ts
@@ -1,11 +1,8 @@
 import type { ConfigSchema } from "../../shared/types/Config";
 
-export interface Setting {
-  name: string;
-  appId: string;
-  targetField: string;
-  prefix: string;
-}
+// Auto-derive ConfigSetting type from ConfigSchema for better maintainability
+// This ensures schema and types stay in sync automatically
+export type ConfigSetting = ConfigSchema["settings"][number];
 
 export interface ConfigFormState {
   formData: ConfigSchema;
@@ -18,7 +15,7 @@ export interface ConfigFormActions {
   handleTabChange: (event: React.SyntheticEvent, newValue: number) => void;
   handleAddTab: () => void;
   handleDeleteTab: (index: number) => void;
-  handleUpdateSetting: (index: number, settingData: Setting) => void;
+  handleUpdateSetting: (index: number, settingData: ConfigSetting) => void;
 }
 
 export interface ConfigFormProps {

--- a/src/config/utils/configUtils.ts
+++ b/src/config/utils/configUtils.ts
@@ -1,10 +1,10 @@
 import type { ConfigSchema } from "../../shared/types/Config";
-import type { Setting } from "../types/ConfigFormTypes";
+import type { ConfigSetting } from "../types/ConfigFormTypes";
 
 /**
  * 新しい設定項目を作成する純粋関数
  */
-export const createNewSetting = (index: number): Setting => ({
+export const createNewSetting = (index: number): ConfigSetting => ({
   name: `設定 ${index + 1}`,
   appId: "",
   targetField: "",
@@ -38,7 +38,7 @@ export const deleteSetting = (
 export const updateSetting = (
   formData: ConfigSchema,
   index: number,
-  settingData: Setting,
+  settingData: ConfigSetting,
 ): ConfigSchema => {
   const newSettings = [...formData.settings];
   newSettings[index] = settingData;


### PR DESCRIPTION
## 📋 Summary

This PR refactors type definitions to automatically derive `ConfigSetting` from `ConfigSchema`, eliminating manual type maintenance and ensuring schema-type consistency.

## 🔧 Changes Made

### Type Definition Refactoring
- **Before**: Manual `Setting` interface definition (maintenance risk)
- **After**: Auto-derived `ConfigSetting` type using TypeScript utility types

```typescript
// Before: Manual definition
export interface Setting {
  name: string;
  appId: string;
  targetField: string;
  prefix: string;
}

// After: Auto-derived from ConfigSchema
export type ConfigSetting = ConfigSchema["settings"][number];
```

### Files Updated
- `ConfigFormTypes.ts`: Main type definition with auto-derivation
- `SettingForm.tsx`: Component props interface updated
- `useConfigData.ts`: Hook return type updated  
- `configUtils.ts`: Utility function parameters updated

## 📈 Benefits

### Maintainability Improvements
- ✅ **Single Source of Truth**: JSON schema is now the authoritative data structure
- ✅ **Automatic Synchronization**: Types update automatically when schema changes
- ✅ **Reduced Manual Work**: No need to manually maintain duplicate type definitions
- ✅ **Consistency Guarantee**: Eliminates schema-type sync issues

### Developer Experience
- ✅ **Clearer Naming**: `ConfigSetting` is more descriptive than `Setting`
- ✅ **Better IDE Support**: Improved autocomplete and type inference
- ✅ **Future-Proof**: Easy schema extensions without manual type updates

## 🧪 Testing

- ✅ ESLint passes (no type errors)
- ✅ TypeScript compilation successful
- ✅ Build process completes without issues
- ✅ All type references updated correctly

## 💡 Technical Approach

Uses TypeScript's indexed access types (`ConfigSchema["settings"][number]`) to automatically extract the array element type from the schema, ensuring the derived type always matches the actual data structure defined in the JSON schema.

This follows the principle of "Single Source of Truth" where the JSON schema serves as the canonical definition, and all TypeScript types are derived from it.

Closes #14

🤖 Generated with [Claude Code](https://claude.ai/code)