### PR TITLE
settingsにbodyフィールドを追加

### DIFF
--- a/src/config/utils/configUtils.ts
+++ b/src/config/utils/configUtils.ts
@@ -18,6 +18,7 @@ export const createNewSetting = (index: number): ConfigSetting => ({
   targetField: "",
   timestampField: "",
   prefix: "",
+  body: "",
 });
 
 /**
@@ -99,6 +100,7 @@ const ensureSettingProperties = (setting: any): ConfigSetting => ({
   targetField: setting.targetField || "",
   timestampField: setting.timestampField || "", // timestampField追加によるバリデーションエラー対策
   prefix: setting.prefix || "",
+  body: setting.body || "", // body追加によるバリデーションエラー対策
 });
 
 /**

--- a/src/config/utils/schemaUtils.ts
+++ b/src/config/utils/schemaUtils.ts
@@ -100,4 +100,7 @@ export const createSettingUiSchema = () => ({
   prefix: {
     "ui:widget": "textarea",
   },
+  body: {
+    "ui:widget": "textarea",
+  },
 });

--- a/src/shared/jsonSchema/config.schema.json
+++ b/src/shared/jsonSchema/config.schema.json
@@ -41,9 +41,13 @@
           "prefix": {
             "type": "string",
             "title": "通知メッセージのプレフィックス"
+          },
+          "body": {
+            "type": "string",
+            "title": "通知メッセージのボディ"
           }
         },
-        "required": ["name", "appId", "targetField", "timestampField", "prefix"],
+        "required": ["name", "appId", "targetField", "timestampField", "prefix", "body"],
         "additionalProperties": false
       }
     }

--- a/src/shared/types/Config.ts
+++ b/src/shared/types/Config.ts
@@ -12,12 +12,14 @@ export type NoName5 = string;
 export type NoName6 = string;
 export type NoName7 = string;
 export type NoName8 = string;
+export type NoName9 = string;
 export type NoName3 = {
   name: NoName4;
   appId: NoName5;
   targetField: NoName6;
   timestampField: NoName7;
   prefix: NoName8;
+  body: NoName9;
 }[];
 
 export interface ConfigSchema {


### PR DESCRIPTION
## 概要
個別設定（settings）に"body"フィールドを追加し、"通知メッセージのプレフィックス"と同じUIで設定できるようにします。

## 実装計画
- [x] GitHub issue作成 (#32)
- [x] ブランチ作成
- [x] JSON Schemaに`body`フィールド追加
- [x] UI Schemaで`textarea`ウィジェット設定
- [x] デフォルト値とバリデーション設定追加
- [x] 型定義更新
- [x] 動作確認テスト

## 実装詳細
- **フィールド名**: `body`
- **タイトル**: "通知メッセージのボディ"
- **UIウィジェット**: `textarea`（複数行入力対応）
- **必須フィールド**: Yes
- **デフォルト値**: 空文字列

## 期待される結果
- 個別設定に"通知メッセージのボディ"フィールドが追加
- prefixと同様のtextarea UIで複数行入力が可能
- 設定の保存・読み込みが正常に動作

## 関連issue
Closes #32

🤖 Generated with [Claude Code](https://claude.ai/code)