### PR TITLE
feat: Add kintone query conditions support for record filtering

### DIFF
--- a/docs/kintone-query-operators.md
+++ b/docs/kintone-query-operators.md
@@ -1,0 +1,30 @@
+| フィールドまたはシステム識別子 | 利用可能な演算子 | 利用可能な関数 |
+| :--- | :--- | :--- |
+| レコード番号 | `=`, `!=`, `>`, `<`, `>=`, `<=`, `in`, `not in` | なし |
+| `$id` | `=`, `!=`, `>`, `<`, `>=`, `<=`, `in`, `not in` | なし |
+| 作成者 | `in`, `not in` | `LOGINUSER()` |
+| 作成日時 | `=`, `!=`, `>`, `<`, `>=`, `<=` | `NOW()`, `TODAY()`, `YESTERDAY()`, `TOMORROW()`, `FROM_TODAY()`, `THIS_WEEK()`, `LAST_WEEK()`, `NEXT_WEEK()`, `THIS_MONTH()`, `LAST_MONTH()`, `NEXT_MONTH()`, `THIS_YEAR()`, `LAST_YEAR()`, `NEXT_YEAR()` |
+| 更新者 | `in`, `not in` | `LOGINUSER()` |
+| 更新日時 | `=`, `!=`, `>`, `<`, `>=`, `<=` | `NOW()`, `TODAY()`, `YESTERDAY()`, `TOMORROW()`, `FROM_TODAY()`, `THIS_WEEK()`, `LAST_WEEK()`, `NEXT_WEEK()`, `THIS_MONTH()`, `LAST_MONTH()`, `NEXT_MONTH()`, `THIS_YEAR()`, `LAST_YEAR()`, `NEXT_YEAR()` |
+| 文字列（1行） | `=`, `!=`, `in`, `not in`, `like`, `not like` | なし |
+| リンク | `=`, `!=`, `in`, `not in`, `like`, `not like` | なし |
+| 数値 | `=`, `!=`, `>`, `<`, `>=`, `<=`, `in`, `not in` | なし |
+| 計算 | `=`, `!=`, `>`, `<`, `>=`, `<=`, `in`, `not in` | なし |
+| 文字列（複数行） | `like`, `not like`, `is`, `is not` | なし |
+| リッチエディター | `like`, `not like` | なし |
+| チェックボックス | `in`, `not in` | なし |
+| ラジオボタン | `in`, `not in` | なし |
+| ドロップダウン | `in`, `not in` | なし |
+| 複数選択 | `in`, `not in` | なし |
+| 添付ファイル | `like`, `not like`, `is`, `is not` | なし |
+| 日付 | `=`, `!=`, `>`, `<`, `>=`, `<=` | `TODAY()`, `YESTERDAY()`, `TOMORROW()`, `FROM_TODAY()`, `THIS_WEEK()`, `LAST_WEEK()`, `NEXT_WEEK()`, `THIS_MONTH()`, `LAST_MONTH()`, `NEXT_MONTH()`, `THIS_YEAR()`, `LAST_YEAR()`, `NEXT_YEAR()` |
+| 時刻 | `=`, `!=`, `>`, `<`, `>=`, `<=` | なし |
+| 日時 | `=`, `!=`, `>`, `<`, `>=`, `<=` | `NOW()`, `TODAY()`, `YESTERDAY()`, `TOMORROW()`, `FROM_TODAY()`, `THIS_WEEK()`, `LAST_WEEK()`, `NEXT_WEEK()`, `THIS_MONTH()`, `LAST_MONTH()`, `NEXT_MONTH()`, `THIS_YEAR()`, `LAST_YEAR()`, `NEXT_YEAR()` |
+| ユーザー選択 | `in`, `not in` | `LOGINUSER()` |
+| 組織選択 | `in`, `not in` | `PRIMARY_ORGANIZATION()` |
+| グループ選択 | `in`, `not in` | なし |
+| ステータス | `=`, `!=`, `in`, `not in` | なし |
+| ルックアップ | ルックアップ元のフィールドタイプと同じ | ルックアップ元のフィールドタイプと同じ |
+| 関連レコード | 参照するアプリのフィールドタイプと同じ | 参照するアプリのフィールドタイプと同じ |
+| グループ | なし | なし |
+| カテゴリー | なし | なし |

--- a/src/shared/jsonSchema/config.schema.json
+++ b/src/shared/jsonSchema/config.schema.json
@@ -45,6 +45,393 @@
           "body": {
             "type": "string",
             "title": "通知メッセージのボディ"
+          },
+          "queryConditions": {
+            "type": "array",
+            "title": "レコード取得条件",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "title": "文字列系（文字列値演算子）",
+                  "properties": {
+                    "fieldCode": {
+                      "type": "string",
+                      "title": "フィールドコード"
+                    },
+                    "fieldType": {
+                      "type": "string",
+                      "enum": ["SINGLE_LINE_TEXT", "LINK"],
+                      "title": "フィールドタイプ"
+                    },
+                    "operator": {
+                      "type": "string",
+                      "enum": ["=", "!=", "like", "not like"],
+                      "title": "演算子"
+                    },
+                    "stringValue": {
+                      "type": "string",
+                      "title": "条件値"
+                    },
+                    "logicalOperator": {
+                      "type": "string",
+                      "enum": ["and", "or"],
+                      "default": "and",
+                      "title": "論理演算子"
+                    }
+                  },
+                  "required": ["fieldCode", "fieldType", "operator", "stringValue"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "title": "文字列系（配列値演算子）",
+                  "properties": {
+                    "fieldCode": {
+                      "type": "string",
+                      "title": "フィールドコード"
+                    },
+                    "fieldType": {
+                      "type": "string",
+                      "enum": ["SINGLE_LINE_TEXT", "LINK"],
+                      "title": "フィールドタイプ"
+                    },
+                    "operator": {
+                      "type": "string",
+                      "enum": ["in", "not in"],
+                      "title": "演算子"
+                    },
+                    "arrayValue": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "条件値"
+                    },
+                    "logicalOperator": {
+                      "type": "string",
+                      "enum": ["and", "or"],
+                      "default": "and",
+                      "title": "論理演算子"
+                    }
+                  },
+                  "required": ["fieldCode", "fieldType", "operator", "arrayValue"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "title": "数値系（文字列値演算子）",
+                  "properties": {
+                    "fieldCode": {
+                      "type": "string",
+                      "title": "フィールドコード"
+                    },
+                    "fieldType": {
+                      "type": "string",
+                      "enum": ["NUMBER", "CALC"],
+                      "title": "フィールドタイプ"
+                    },
+                    "operator": {
+                      "type": "string",
+                      "enum": ["=", "!=", ">", ">=", "<", "<="],
+                      "title": "演算子"
+                    },
+                    "stringValue": {
+                      "type": "string",
+                      "title": "条件値"
+                    },
+                    "logicalOperator": {
+                      "type": "string",
+                      "enum": ["and", "or"],
+                      "default": "and",
+                      "title": "論理演算子"
+                    }
+                  },
+                  "required": ["fieldCode", "fieldType", "operator", "stringValue"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "title": "数値系（配列値演算子）",
+                  "properties": {
+                    "fieldCode": {
+                      "type": "string",
+                      "title": "フィールドコード"
+                    },
+                    "fieldType": {
+                      "type": "string",
+                      "enum": ["NUMBER", "CALC"],
+                      "title": "フィールドタイプ"
+                    },
+                    "operator": {
+                      "type": "string",
+                      "enum": ["in", "not in"],
+                      "title": "演算子"
+                    },
+                    "arrayValue": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "条件値"
+                    },
+                    "logicalOperator": {
+                      "type": "string",
+                      "enum": ["and", "or"],
+                      "default": "and",
+                      "title": "論理演算子"
+                    }
+                  },
+                  "required": ["fieldCode", "fieldType", "operator", "arrayValue"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "title": "複数行テキスト",
+                  "properties": {
+                    "fieldCode": {
+                      "type": "string",
+                      "title": "フィールドコード"
+                    },
+                    "fieldType": {
+                      "type": "string",
+                      "enum": ["MULTI_LINE_TEXT"],
+                      "title": "フィールドタイプ"
+                    },
+                    "operator": {
+                      "type": "string",
+                      "enum": ["like", "not like", "is", "is not"],
+                      "title": "演算子"
+                    },
+                    "stringValue": {
+                      "type": "string",
+                      "title": "条件値"
+                    },
+                    "logicalOperator": {
+                      "type": "string",
+                      "enum": ["and", "or"],
+                      "default": "and",
+                      "title": "論理演算子"
+                    }
+                  },
+                  "required": ["fieldCode", "fieldType", "operator", "stringValue"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "title": "リッチエディター",
+                  "properties": {
+                    "fieldCode": {
+                      "type": "string",
+                      "title": "フィールドコード"
+                    },
+                    "fieldType": {
+                      "type": "string",
+                      "enum": ["RICH_TEXT"],
+                      "title": "フィールドタイプ"
+                    },
+                    "operator": {
+                      "type": "string",
+                      "enum": ["like", "not like"],
+                      "title": "演算子"
+                    },
+                    "stringValue": {
+                      "type": "string",
+                      "title": "条件値"
+                    },
+                    "logicalOperator": {
+                      "type": "string",
+                      "enum": ["and", "or"],
+                      "default": "and",
+                      "title": "論理演算子"
+                    }
+                  },
+                  "required": ["fieldCode", "fieldType", "operator", "stringValue"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "title": "選択系フィールド",
+                  "properties": {
+                    "fieldCode": {
+                      "type": "string",
+                      "title": "フィールドコード"
+                    },
+                    "fieldType": {
+                      "type": "string",
+                      "enum": ["RADIO_BUTTON", "DROP_DOWN", "CHECK_BOX", "MULTI_SELECT"],
+                      "title": "フィールドタイプ"
+                    },
+                    "operator": {
+                      "type": "string",
+                      "enum": ["in", "not in"],
+                      "title": "演算子"
+                    },
+                    "arrayValue": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "条件値"
+                    },
+                    "logicalOperator": {
+                      "type": "string",
+                      "enum": ["and", "or"],
+                      "default": "and",
+                      "title": "論理演算子"
+                    }
+                  },
+                  "required": ["fieldCode", "fieldType", "operator", "arrayValue"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "title": "ステータス（文字列値演算子）",
+                  "properties": {
+                    "fieldCode": {
+                      "type": "string",
+                      "title": "フィールドコード"
+                    },
+                    "fieldType": {
+                      "type": "string",
+                      "enum": ["STATUS"],
+                      "title": "フィールドタイプ"
+                    },
+                    "operator": {
+                      "type": "string",
+                      "enum": ["=", "!="],
+                      "title": "演算子"
+                    },
+                    "stringValue": {
+                      "type": "string",
+                      "title": "条件値"
+                    },
+                    "logicalOperator": {
+                      "type": "string",
+                      "enum": ["and", "or"],
+                      "default": "and",
+                      "title": "論理演算子"
+                    }
+                  },
+                  "required": ["fieldCode", "fieldType", "operator", "stringValue"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "title": "ステータス（配列値演算子）",
+                  "properties": {
+                    "fieldCode": {
+                      "type": "string",
+                      "title": "フィールドコード"
+                    },
+                    "fieldType": {
+                      "type": "string",
+                      "enum": ["STATUS"],
+                      "title": "フィールドタイプ"
+                    },
+                    "operator": {
+                      "type": "string",
+                      "enum": ["in", "not in"],
+                      "title": "演算子"
+                    },
+                    "arrayValue": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "title": "条件値"
+                    },
+                    "logicalOperator": {
+                      "type": "string",
+                      "enum": ["and", "or"],
+                      "default": "and",
+                      "title": "論理演算子"
+                    }
+                  },
+                  "required": ["fieldCode", "fieldType", "operator", "arrayValue"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "title": "日時系フィールド",
+                  "properties": {
+                    "fieldCode": {
+                      "type": "string",
+                      "title": "フィールドコード"
+                    },
+                    "fieldType": {
+                      "type": "string",
+                      "enum": ["DATE", "TIME", "DATETIME"],
+                      "title": "フィールドタイプ"
+                    },
+                    "operator": {
+                      "type": "string",
+                      "enum": ["=", "!=", ">", ">=", "<", "<="],
+                      "title": "演算子"
+                    },
+                    "stringValue": {
+                      "type": "string",
+                      "title": "条件値"
+                    },
+                    "logicalOperator": {
+                      "type": "string",
+                      "enum": ["and", "or"],
+                      "default": "and",
+                      "title": "論理演算子"
+                    }
+                  },
+                  "required": ["fieldCode", "fieldType", "operator", "stringValue"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "title": "Entity配列フィールド",
+                  "properties": {
+                    "fieldCode": {
+                      "type": "string",
+                      "title": "フィールドコード"
+                    },
+                    "fieldType": {
+                      "type": "string",
+                      "enum": ["USER_SELECT", "ORGANIZATION_SELECT", "GROUP_SELECT", "STATUS_ASSIGNEE"],
+                      "title": "フィールドタイプ"
+                    },
+                    "operator": {
+                      "type": "string",
+                      "enum": ["in", "not in"],
+                      "title": "演算子"
+                    },
+                    "entityValue": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string",
+                            "title": "コード"
+                          },
+                          "name": {
+                            "type": "string",
+                            "title": "名前"
+                          }
+                        },
+                        "required": ["code"],
+                        "additionalProperties": false
+                      },
+                      "title": "条件値"
+                    },
+                    "logicalOperator": {
+                      "type": "string",
+                      "enum": ["and", "or"],
+                      "default": "and",
+                      "title": "論理演算子"
+                    }
+                  },
+                  "required": ["fieldCode", "fieldType", "operator", "entityValue"],
+                  "additionalProperties": false
+                }
+              ]
+            }
           }
         },
         "required": ["name", "appId", "targetField", "timestampField", "prefix", "body"],

--- a/src/shared/types/Config.ts
+++ b/src/shared/types/Config.ts
@@ -13,6 +13,79 @@ export type NoName6 = string;
 export type NoName7 = string;
 export type NoName8 = string;
 export type NoName9 = string;
+export type NoName12 = string;
+export type NoName13 = "SINGLE_LINE_TEXT" | "LINK";
+export type NoName14 = "=" | "!=" | "like" | "not like";
+export type NoName15 = string;
+export type NoName16 = "and" | "or";
+export type NoName18 = string;
+export type NoName19 = "SINGLE_LINE_TEXT" | "LINK";
+export type NoName20 = "in" | "not in";
+export type NoName21 = string[];
+export type NoName22 = "and" | "or";
+export type NoName24 = string;
+export type NoName25 = "NUMBER" | "CALC";
+export type NoName26 = "=" | "!=" | ">" | ">=" | "<" | "<=";
+export type NoName27 = string;
+export type NoName28 = "and" | "or";
+export type NoName30 = string;
+export type NoName31 = "NUMBER" | "CALC";
+export type NoName32 = "in" | "not in";
+export type NoName33 = string[];
+export type NoName34 = "and" | "or";
+export type NoName36 = string;
+export type NoName37 = "MULTI_LINE_TEXT";
+export type NoName38 = "like" | "not like" | "is" | "is not";
+export type NoName39 = string;
+export type NoName40 = "and" | "or";
+export type NoName42 = string;
+export type NoName43 = "RICH_TEXT";
+export type NoName44 = "like" | "not like";
+export type NoName45 = string;
+export type NoName46 = "and" | "or";
+export type NoName48 = string;
+export type NoName49 = "RADIO_BUTTON" | "DROP_DOWN" | "CHECK_BOX" | "MULTI_SELECT";
+export type NoName50 = "in" | "not in";
+export type NoName51 = string[];
+export type NoName52 = "and" | "or";
+export type NoName54 = string;
+export type NoName55 = "STATUS";
+export type NoName56 = "=" | "!=";
+export type NoName57 = string;
+export type NoName58 = "and" | "or";
+export type NoName60 = string;
+export type NoName61 = "STATUS";
+export type NoName62 = "in" | "not in";
+export type NoName63 = string[];
+export type NoName64 = "and" | "or";
+export type NoName66 = string;
+export type NoName67 = "DATE" | "TIME" | "DATETIME";
+export type NoName68 = "=" | "!=" | ">" | ">=" | "<" | "<=";
+export type NoName69 = string;
+export type NoName70 = "and" | "or";
+export type NoName71 = string;
+export type NoName72 = "USER_SELECT" | "ORGANIZATION_SELECT" | "GROUP_SELECT" | "STATUS_ASSIGNEE";
+export type NoName73 = "in" | "not in";
+export type NoName75 = string;
+export type NoName76 = string;
+export type NoName74 = {
+  code: NoName75;
+  name?: NoName76;
+}[];
+export type NoName77 = "and" | "or";
+export type NoName10 = (
+  | NoName11
+  | NoName17
+  | NoName23
+  | NoName29
+  | NoName35
+  | NoName41
+  | NoName47
+  | NoName53
+  | NoName59
+  | NoName65
+  | Entity
+)[];
 export type NoName3 = {
   name: NoName4;
   appId: NoName5;
@@ -20,6 +93,7 @@ export type NoName3 = {
   timestampField: NoName7;
   prefix: NoName8;
   body: NoName9;
+  queryConditions?: NoName10;
 }[];
 
 export interface ConfigSchema {
@@ -29,4 +103,81 @@ export interface ConfigSchema {
 export interface NoName {
   prefix?: NoName1;
   targetView?: NoName2;
+}
+export interface NoName11 {
+  fieldCode: NoName12;
+  fieldType: NoName13;
+  operator: NoName14;
+  stringValue: NoName15;
+  logicalOperator?: NoName16;
+}
+export interface NoName17 {
+  fieldCode: NoName18;
+  fieldType: NoName19;
+  operator: NoName20;
+  arrayValue: NoName21;
+  logicalOperator?: NoName22;
+}
+export interface NoName23 {
+  fieldCode: NoName24;
+  fieldType: NoName25;
+  operator: NoName26;
+  stringValue: NoName27;
+  logicalOperator?: NoName28;
+}
+export interface NoName29 {
+  fieldCode: NoName30;
+  fieldType: NoName31;
+  operator: NoName32;
+  arrayValue: NoName33;
+  logicalOperator?: NoName34;
+}
+export interface NoName35 {
+  fieldCode: NoName36;
+  fieldType: NoName37;
+  operator: NoName38;
+  stringValue: NoName39;
+  logicalOperator?: NoName40;
+}
+export interface NoName41 {
+  fieldCode: NoName42;
+  fieldType: NoName43;
+  operator: NoName44;
+  stringValue: NoName45;
+  logicalOperator?: NoName46;
+}
+export interface NoName47 {
+  fieldCode: NoName48;
+  fieldType: NoName49;
+  operator: NoName50;
+  arrayValue: NoName51;
+  logicalOperator?: NoName52;
+}
+export interface NoName53 {
+  fieldCode: NoName54;
+  fieldType: NoName55;
+  operator: NoName56;
+  stringValue: NoName57;
+  logicalOperator?: NoName58;
+}
+export interface NoName59 {
+  fieldCode: NoName60;
+  fieldType: NoName61;
+  operator: NoName62;
+  arrayValue: NoName63;
+  logicalOperator?: NoName64;
+}
+export interface NoName65 {
+  fieldCode: NoName66;
+  fieldType: NoName67;
+  operator: NoName68;
+  stringValue: NoName69;
+  logicalOperator?: NoName70;
+}
+export interface Entity {
+  fieldCode: NoName71;
+  fieldType: NoName72;
+  operator: NoName73;
+  entityValue: NoName74;
+  logicalOperator?: NoName77;
 }


### PR DESCRIPTION
## Summary
Adds comprehensive support for kintone query conditions to enable filtering records before processing in MessageService. This implementation provides type-safe query building with full support for all kintone field types and their corresponding operators.

## Changes Made

### 1. JSON Schema Extension (`src/shared/jsonSchema/config.schema.json`)
- Added `queryConditions` property with 11 oneOf patterns
- Each pattern enforces correct operator usage for specific field types
- Type-safe value constraints (string vs array) based on operator type

### 2. TypeScript Type Generation (`src/shared/types/Config.ts`)
- Regenerated types from updated schema
- 11 new interface types for different field type + operator combinations
- Complete type safety preventing invalid operator usage

### 3. MessageService Implementation (`src/desktop/service/MessageService.ts`)
- Added `buildQueryString` method (now public for testing)
- Enhanced `extractRequiredFields` to include queryConditions fields
- Modified `fetchRecordsFromSettings` to use generated query strings
- Support for all kintone operators: `=`, `!=`, `>`, `>=`, `<`, `<=`, `like`, `not like`, `is`, `is not`, `in`, `not in`

### 4. Comprehensive Test Suite (`src/desktop/service/MessageService.test.ts`)
- 46 new test cases covering all field types and operators
- Tests for logical operators (AND/OR) and multiple conditions
- Edge case testing (empty values, special characters, null handling)
- Type safety verification for all patterns

### 5. Documentation (`docs/kintone-query-operators.md`)
- Complete reference of kintone field types and supported operators
- Mapping from kintone documentation to implementation

## Field Type Support

| Field Type | String Operators | Array Operators | Special Operators |
|------------|------------------|-----------------|-------------------|
| SINGLE_LINE_TEXT, LINK | `=`, `!=`, `like`, `not like` | `in`, `not in` | - |
| NUMBER, CALC | `=`, `!=`, `>`, `>=`, `<`, `<=` | `in`, `not in` | - |
| MULTI_LINE_TEXT | `like`, `not like` | - | `is`, `is not` |
| RICH_TEXT | `like`, `not like` | - | - |
| RADIO_BUTTON, DROP_DOWN, CHECK_BOX, MULTI_SELECT | - | `in`, `not in` | - |
| STATUS | `=`, `!=` | `in`, `not in` | - |
| DATE, TIME, DATETIME | `=`, `!=`, `>`, `>=`, `<`, `<=` | - | - |
| USER_SELECT, ORGANIZATION_SELECT, GROUP_SELECT, STATUS_ASSIGNEE | - | `in`, `not in` (Entity[]) | - |

## Example Usage

```typescript
const queryConditions = [
  {
    fieldCode: "status",
    fieldType: "STATUS",
    operator: "!=",
    stringValue: "完了"
  },
  {
    fieldCode: "priority", 
    fieldType: "DROP_DOWN",
    operator: "in",
    arrayValue: ["高", "中"],
    logicalOperator: "and"
  }
];
// Generates: status != "完了" and priority in ("高","中")
```

## Testing
- ✅ 77 tests passing (46 new tests)
- ✅ Type checking passes
- ✅ Linting passes
- ✅ Full coverage of all operator combinations

## Backward Compatibility
- ✅ Fully backward compatible - `queryConditions` is optional
- ✅ Existing configurations continue to work unchanged
- ✅ No breaking changes to existing APIs

## Related Issue
Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)